### PR TITLE
Try html.unescape first to escape HTML

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -13,6 +13,7 @@ import json
 
 from xbmcswift2 import Plugin
 
+import html
 from html.parser import HTMLParser
 from urllib.request import urlopen
 
@@ -44,7 +45,10 @@ def unescape_html(inp):
     >>> unescape_html('apples &amp; oranges')
     apples & oranges
     '''
-    return _parser.unescape(inp)
+    try:
+        return html.unescape(inp)
+    except:
+        return _parser.unescape(inp)
 
 
 def clean(inp):


### PR DESCRIPTION
The unescape function is part of the `html` module since python 3.4 and since 3.9 it's giving an AttributeError when using `HTMLParser.unescape`, so use the `html.unescape` function by default and only fall back to the old method on error (i.e. python < 3.4).